### PR TITLE
replace mystery reboot role with win_reboot task [fix #1]

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,8 +24,7 @@
   register: services
 
 - name: Reboot for WSUS Install
-  import_role:
-    name: reboot
+  win_reboot:
   when:
     wsus.reboot_required
     or widdb.reboot_required or services.reboot_required


### PR DESCRIPTION
This change fixes issue #1 and the role still works, tested.