### PR TITLE
Enable idempotent configuration of languages through variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The following variables are defined in `/vars/main.yml`:
 * `install_management_tools`: Whether to install the WSUS MMC or not.  Default is `yes`
 * `content_folder`: Sets the folder location for WSUS to store its content.  Default is `C:\WSUS`
 * `script_folder`: Sets the folder for storing WSUS scripts. Default is `C:\WSUS\Scripts\`
-* `log_folder`: Sets the folder for logging WSUS related items. Default
-is `C:\WSUS\Logs`
+* `log_folder`: Sets the folder for logging WSUS related items. Default is `C:\WSUS\Logs`
 * `products_list`: A list of products which updates will be downloaded for.  Default items are `Windows Server 2016` and `Windows Server 2019`
 * `classification_list`: A list of the Update Classifications that will be enabled.  Default items are `Critical Updates` and `Security Updates`
 * `use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
 * `wsus_facts`: Determines whether WSUS facts should be returned
+* `wsus_languages`: A list of languages for which updates will be downloaded by WSUS. Default is just `en` (English)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
-# defaults file for wsus
+
+wsus_languages:
+  - en

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,16 +10,33 @@
     chdir: 'C:\Program Files\Update Services\Tools'
     creates: "{{ content_folder }}\\WSUSContent"
 
+- name: Get current enabled languages in WSUS
+  win_shell: |
+    $wsuscfg = (Get-WsusServer).GetConfiguration()
+    [PSCustomObject]@{
+      'AllUpdateLanguagesEnabled' = $wsuscfg.AllUpdateLanguagesEnabled
+      'EnabledUpdateLanguages'    = @($wsuscfg.GetEnabledUpdateLanguages())
+    } | ConvertTo-Json
+  register: _currentwsuslanguages_command
+  changed_when: false
+
+- name: Parse current enabled languages from JSON
+  set_fact:
+    _currentwsuslanguages: "{{ _currentwsuslanguages_command.stdout | from_json() }}"
+
+- name: Set update languages
+  win_shell: |
+    [array]$languages = ConvertFrom-Json -InputObject '{{ wsus_languages | flatten(levels=1) | to_json(ensure_ascii=False) }}'
+    $wsusconfig = (Get-WsusServer).GetConfiguration()
+    $wsusconfig.AllUpdateLanguagesEnabled = $false
+    $wsusconfig.SetEnabledUpdateLanguages($languages)
+    $wsusconfig.Save()
+  when: _currentwsuslanguages.EnabledUpdateLanguages != wsus_languages or
+        _currentwsuslanguages.AllUpdateLanguagesEnabled
+
 - name: Set WSUS to synchronise from Microsoft Update
   win_shell: |
     Set-WsusServerSynchronization -SyncFromMU
-
-- name: Set Updates to English Only
-  win_shell: |
-    $wsusconfig = (Get-WsusServer).GetConfiguration()
-    $wsusconfig.AllUpdateLanguagesEnabled = $false
-    $wsusconfig.SetEnabledUpdateLanguages("en")
-    $wsusconfig.Save()
 
 - name: Configure Proxy for WSUS Server
   win_shell: |
@@ -35,16 +52,10 @@
     - wsus_proxy is defined
     - wsus_proxy_port is defined
 
-
 - name: Get Synchronization Source State
   win_shell: |
     (Get-WsusServer).GetConfiguration().SyncFromMicrosoftUpdate
   register: wsus_sync_source_state_raw
-
-- name: Get All Languages Enabled State
-  win_shell: |
-    (Get-WsusServer).GetConfiguration().AllUpdateLanguagesEnabled
-  register: wsus_all_languages_enabled_raw
 
 - name: Get Last Sync Year
   win_shell: |

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,7 +31,7 @@
     $wsusconfig.AllUpdateLanguagesEnabled = $false
     $wsusconfig.SetEnabledUpdateLanguages($languages)
     $wsusconfig.Save()
-  when: _currentwsuslanguages.EnabledUpdateLanguages != wsus_languages or
+  when: _currentwsuslanguages.EnabledUpdateLanguages | symmetric_difference(wsus_languages) | length > 0 or
         _currentwsuslanguages.AllUpdateLanguagesEnabled
 
 - name: Set WSUS to synchronise from Microsoft Update

--- a/tasks/syncronize.yml
+++ b/tasks/syncronize.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Start synchronization
   win_shell: |
     $wsus = Get-WSUSServer


### PR DESCRIPTION
This is one PR of more to come.

- Enables the user to idempotently configure the languages they want in WSUS through the `wsus_languages` variable
- Default behavior/value is just "en" just as before, but now the user can override this e.g. like this:

```
- hosts: all
  vars:
    wsus_languages:
      - en
      - de
  roles:
    - ansible_role_wsus_server
```

Changes will only be made if needed.

I tested the changes in this PR against a fresh Windows Server 2019 VM to verify it works as intended.