### PR TITLE
Make daily sync time configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The following variables are defined in `/vars/main.yml`:
 * `use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
 * `wsus_facts`: Determines whether WSUS facts should be returned
 * `wsus_languages`: A list of languages for which updates will be downloaded by WSUS. Default is just `en` (English)
+* ```wsus_sync_daily_time:
+    hour: 0
+    minute: 0```
+  Set the time of day when WSUS will run an automatic synchronization. Use `hour: 0` for midnight.
 
 Dependencies
 ------------
@@ -46,6 +50,7 @@ An example playbook for using this role:
     roles:
       - wsus
 ```
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ The following variables are defined in `/vars/main.yml`:
 * `use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
 * `wsus_facts`: Determines whether WSUS facts should be returned
 * `wsus_languages`: A list of languages for which updates will be downloaded by WSUS. Default is just `en` (English)
-* ```wsus_sync_daily_time:
+* ```
+  wsus_sync_daily_time:
     hour: 0
-    minute: 0```
+    minute: 0
+  ```
   Set the time of day when WSUS will run an automatic synchronization. Use `hour: 0` for midnight.
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,8 @@
 
 wsus_languages:
   - en
+
+# Use 0 for midnight, not 24
+wsus_sync_daily_time:
+  hour: 0
+  minute: 0

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -101,13 +101,29 @@
     Get-WSUSProduct | Where-Object -FilterScript {$_.product.title -eq "{{ item }}" } | Set-WsusProduct
   loop: "{{ products_list|flatten(levels=1) }}"
 
-- name: Enable Synchronization at Midnight every day
+- name: Set automatic daily synchronization
   win_shell: |
+    $changed = $false
+    $newTime = [TimeSpan]::new({{ wsus_sync_daily_time.hour }}, {{ wsus_sync_daily_time.minute }}, 0)
     $wsussubscription = (Get-WSUSServer).GetSubscription()
-    $wsussubscription.SynchronizeAutomatically=$true
-    $wsussubscription.SynchronizeAutomaticallyTimeOfDay= (New-TimeSpan -Hours 0)
-    $wsussubscription.NumberOfSynchronizationsPerDay=1
-    $wsussubscription.Save()
+    if (-not $wsussubscription.SynchronizeAutomatically) {
+      $wsussubscription.SynchronizeAutomatically = $true
+      $changed = $true
+    }
+    if ($wsussubscription.SynchronizeAutomaticallyTimeOfDay -ne $newTime) {
+      $wsussubscription.SynchronizeAutomaticallyTimeOfDay = $newTime
+      $changed = $true
+    }
+    if ($wsussubscription.NumberOfSynchronizationsPerDay -ne 1) {
+      $wsussubscription.NumberOfSynchronizationsPerDay = 1
+      $changed = $true
+    }
+    if ($changed) {
+      $wsussubscription.Save()
+      Write-Output "change"
+    }
+  register: _dailysync_command
+  changed_when: "'change' in _dailysync_command.stdout"
 
 - name: Enable automatic approval rule
   win_shell: |


### PR DESCRIPTION
- Default to midnight (`00:00`) as before
- Allow user to override with their own preferred time
- Make the tasks idempotent, ansible only reports a change when a change had to be made