### PR TITLE
Make products and classifications configurable and idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following variables are defined in `/vars/main.yml`:
 * `content_folder`: Sets the folder location for WSUS to store its content.  Default is `C:\WSUS`
 * `script_folder`: Sets the folder for storing WSUS scripts. Default is `C:\WSUS\Scripts\`
 * `log_folder`: Sets the folder for logging WSUS related items. Default is `C:\WSUS\Logs`
-* `products_list`: A list of products which updates will be downloaded for.  Default items are `Windows Server 2016` and `Windows Server 2019`
-* `classification_list`: A list of the Update Classifications that will be enabled.  Default items are `Critical Updates` and `Security Updates`
+* `wsus_products_list`: A list of products which updates will be downloaded for. Default items are `Windows Server 2016` and `Windows Server 2019`
+* `wsus_classifications_list`: A list of the Update Classifications that will be enabled. Default items are `Critical Updates` and `Security Updates`
 * `use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
 * `wsus_facts`: Determines whether WSUS facts should be returned
 * `wsus_languages`: A list of languages for which updates will be downloaded by WSUS. Default is just `en` (English)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,9 +15,4 @@ wsus_products_list:
 wsus_classifications_list:
   - Critical Updates
   - Security Updates
-  - Definition Updates
-  - Update Rollups
-  - Updates
-  - Service Packs
-  - Feature Packs
-  - Tools
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,17 @@ wsus_languages:
 wsus_sync_daily_time:
   hour: 0
   minute: 0
+
+wsus_products_list:
+  - Windows Server 2016
+  - Windows Server 2019
+
+wsus_classifications_list:
+  - Critical Updates
+  - Security Updates
+  - Definition Updates
+  - Update Rollups
+  - Updates
+  - Service Packs
+  - Feature Packs
+  - Tools

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -83,23 +83,52 @@
   delay: 60
   ignore_errors: true
 
-- name: Disable all classifications
+- name: Set classifications to synchronize
   win_shell: |
-    Get-WsusClassification | Set-WsusClassification -Disable
+    [array]$current = (Get-WsusServer).GetSubscription().GetUpdateClassifications()
+    [array]$allClassifications = Get-WsusClassification
+    [array]$shouldTitles = ConvertFrom-Json @'
+    {{ wsus_classifications_list | flatten(levels=1) | to_json() }}
+    '@
+    [array]$should = ($allClassifications | Where-Object { $_.Classification.Title -in $shouldTitles }).Classification
+    $diffs = Compare-Object $current $should -Property Id
+    if ($diffs) {
+      foreach ($classification in $diffs) {
+        if ($classification.SideIndicator -eq '<=') {
+          $allClassifications.Where{ $_.Classification.Id -eq $classification.Id } | Set-WsusClassification -Disable
+        }
+        if ($classification.SideIndicator -eq '=>') {
+          $allClassifications.Where{ $_.Classification.Id -eq $classification.Id } | Set-WsusClassification
+        }
+      }
+      Write-Output "change"
+    }
+  register: _classificationsenable_command
+  changed_when: "'change' in _classificationsenable_command.stdout"
 
-- name: Set classifications -> loop
+- name: Set products to synchronize
   win_shell: |
-    Get-WsusClassification | Where-Object -FilterScript {$_.Classification.Title -Eq "{{ item }}"} | Set-WsusClassification
-  loop: "{{ classification_list|flatten(levels=1) }}"
-
-- name: Disable All Products
-  win_shell: |
-    Get-WsusProduct | Set-WsusProduct -Disable
-
-- name: Set products to synchronise -> loop
-  win_shell: |
-    Get-WSUSProduct | Where-Object -FilterScript {$_.product.title -eq "{{ item }}" } | Set-WsusProduct
-  loop: "{{ products_list|flatten(levels=1) }}"
+    [array]$current = (Get-WsusServer).GetSubscription().GetUpdateCategories()
+    [array]$allProducts = Get-WSUSProduct
+    [array]$shouldTitles = ConvertFrom-Json @'
+    {{ wsus_products_list | flatten(levels=1) | to_json() }}
+    '@
+    [array]$should = ($allProducts | Where-Object { $_.Product.Title -in $shouldTitles }).Product
+    $diffs = Compare-Object $current $should -Property Id
+    if ($diffs) {
+      $changed = $true
+      foreach ($product in $diffs) {
+        if ($product.SideIndicator -eq '<=') {
+          $allProducts.Where{ $_.Product.Id -eq $product.Id } | Set-WsusProduct -Disable
+        }
+        if ($product.SideIndicator -eq '=>') {
+          $allProducts.Where{ $_.Product.Id -eq $product.Id } | Set-WsusProduct
+        }
+      }
+      Write-Output "change"
+    }
+  register: _productsenable_command
+  changed_when: "'change' in _productsenable_command.stdout"
 
 - name: Set automatic daily synchronization
   win_shell: |

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,19 +1,9 @@
 ---
+
 use_proxy: false
 wsus_facts: true
 install_management_tools: true
 content_folder: "C:\\WSUS"
 script_folder: "{{content_folder}}\\Scripts"
 log_folder: "{{content_folder}}\\Logs"
-products_list:
-  - "Windows Server 2016"
-  - "Windows Server 2019"
-classification_list:
-  - "Critical Updates"
-  - "Security Updates"
-  - "Definition Updates"
-  - "Update Rollups"
-  - "Updates"
-  - "Service Packs"
-  - "Feature Packs"
-  - "Tools"
+


### PR DESCRIPTION
- Instead of disabling all and re-enabling specific products and classifications (which always results in two CHANGED tasks each), do a comparison of whether anything needs to be changed and disable or enable products and classifications only when needed
- Rename the variables and add a `wsus_` prefix. When a user runs multiple roles against a server, as is often the case, generic names like "products_list" do not provide enough clarity what is meant - it could be any products relating to any role and generic variable names can even cause conflicts when the same variable name is used by more than 1 role
- Moved the variables `wsus_products_list` and `wsus_classifications_list` into defaults/ instead of vars/ so the user can override them
- Adjust the default classifications to only "Critical Updates" and "Security Updates" like the README says
- Updated README with new variable names