### PR TITLE
prefix wsus_ to all variables, fix some formatting and syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Role Variables
 --------------
 
 The following variables are defined in `/vars/main.yml`:
-* `install_management_tools`: Whether to install the WSUS MMC or not.  Default is `yes`
-* `content_folder`: Sets the folder location for WSUS to store its content.  Default is `C:\WSUS`
-* `script_folder`: Sets the folder for storing WSUS scripts. Default is `C:\WSUS\Scripts\`
-* `log_folder`: Sets the folder for logging WSUS related items. Default is `C:\WSUS\Logs`
+* `wsus_install_management_tools`: Whether to install the WSUS MMC or not.  Default is `yes`
+* `wsus_content_folder`: Sets the folder location for WSUS to store its content.  Default is `C:\WSUS`
+* `wsus_script_folder`: Sets the folder for storing WSUS scripts. Default is `C:\WSUS\Scripts\`
+* `wsus_log_folder`: Sets the folder for logging WSUS related items. Default is `C:\WSUS\Logs`
 * `wsus_products_list`: A list of products which updates will be downloaded for. Default items are `Windows Server 2016` and `Windows Server 2019`
 * `wsus_classifications_list`: A list of the Update Classifications that will be enabled. Default items are `Critical Updates` and `Security Updates`
-* `use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
+* `wsus_use_proxy`: Used to determine if proxy for WSUS Server will be configured. Default is `no`, only applies if `wsus_port` and `wsus_proxy` are defined.
 * `wsus_facts`: Determines whether WSUS facts should be returned
 * `wsus_enable_default_approval_rule`: Enable or disable the default approval rule in WSUS
 * `wsus_languages`: A list of languages for which updates will be downloaded by WSUS. Default is just `en` (English)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 
+wsus_content_folder: "C:\\WSUS"
+
+wsus_use_proxy: false
+wsus_install_management_tools: true
 wsus_enable_default_approval_rule: yes
 
 wsus_languages:

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,18 +2,18 @@
 
 - name: Create Script Folder
   win_file:
-    path: "{{ script_folder }}"
+    path: "{{ wsus_script_folder }}"
     state: directory
 
 - name: Create Log Folder
   win_file:
-    path: "{{ log_folder }}"
+    path: "{{ wsus_log_folder }}"
     state: directory
 
-- name: Add WSuSCleanup script
+- name: Copy WSUSCleanup script to machine
   win_template:
     src: wsuscleanup.j2
-    dest: "{{ script_folder }}\\WSUSCleanup.ps1"
+    dest: "{{ wsus_script_folder }}\\WSUSCleanup.ps1"
 
 - name: Create task to run a WSUS cleanup script
   win_scheduled_task:
@@ -21,7 +21,7 @@
     description: Run WSUS Cleanup
     actions:
       - path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        arguments: "-ExecutionPolicy Unrestricted -NonInteractive -File {{ script_folder }}\\WSUSCleanup.ps1"
+        arguments: "-ExecutionPolicy Unrestricted -NonInteractive -File \"{{ wsus_script_folder }}\\WSUSCleanup.ps1\""
     triggers:
       - type: daily
         start_boundary: '2019-04-01T04:00:00'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: Create content folder
+- name: Ensure content directory exists
   win_file:
-    path: "{{ content_folder }}"
+    path: "{{ wsus_content_folder }}"
     state: directory
 
 - name: Set content folder in WSUS
-  win_command: 'WsusUtil.exe postinstall CONTENT_DIR={{ content_folder }}'
+  win_command: 'WsusUtil.exe postinstall CONTENT_DIR={{ wsus_content_folder }}'
   args:
-    chdir: 'C:\Program Files\Update Services\Tools'
-    creates: "{{ content_folder }}\\WSUSContent"
+    chdir: "{{ ansible_env.ProgramFiles }}\\Update Services\\Tools"
+    creates: "{{ wsus_content_folder }}\\WSUSContent"
 
 - name: Get current enabled languages in WSUS
   win_shell: |
@@ -48,7 +48,7 @@
     $wsusConfig.AnonymousProxyAccess = $True
     $wsusConfig.Save()
   when:
-    - use_proxy
+    - wsus_use_proxy
     - wsus_proxy is defined
     - wsus_proxy_port is defined
 
@@ -56,11 +56,13 @@
   win_shell: |
     (Get-WsusServer).GetConfiguration().SyncFromMicrosoftUpdate
   register: wsus_sync_source_state_raw
+  changed_when: false
 
 - name: Get Last Sync Year
   win_shell: |
     (Get-WsusServer).GetSubscription().LastModifiedTime.Year
   register: wsus_last_sync_year_raw
+  changed_when: false
 
 - name: Do initial synchronization to get latest categories
   win_shell: |

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,30 +1,33 @@
 ---
+
 - name: Install UpdateServices
   win_feature:
     name: UpdateServices
     state: present
     include_sub_features: false
-    include_management_tools: "{{ install_management_tools }}"
-  register: wsus
+    include_management_tools: "{{ wsus_install_management_tools }}"
+  register: _wsusfeature
 
 - name: Install UpdateServices-WidDB
   win_feature:
     name: UpdateServices-WidDB
     state: present
     include_sub_features: false
-    include_management_tools: "{{ install_management_tools }}"
-  register: widdb
+    include_management_tools: "{{ wsus_install_management_tools }}"
+  register: _widdb
 
 - name: Install UpdateServices-Services
   win_feature:
     name: UpdateServices-Services
     state: present
     include_sub_features: false
-    include_management_tools: "{{ install_management_tools }}"
-  register: services
+    include_management_tools: "{{ wsus_install_management_tools }}"
+  register: _services
 
 - name: Reboot for WSUS Install
   win_reboot:
   when:
-    wsus.reboot_required
-    or widdb.reboot_required or services.reboot_required
+    _wsusfeature.reboot_required
+    or _widdb.reboot_required
+    or _services.reboot_required
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
+
 - name: Instgall WSUS Binaries
   import_tasks: install.yml
 
 - name: Configure WSUS Server
   import_tasks: configure.yml
 
-- name: configure Auto Cleanup
+- name: Configure Auto Cleanup
   import_tasks: cleanup.yml
 
 - name: Pull updates

--- a/templates/wsuscleanup.j2
+++ b/templates/wsuscleanup.j2
@@ -9,15 +9,13 @@ $TimeOfDay = "04:00:00"
 
 $WsusServer = Get-WsusServer
 
-if($WsusServer)
-{
+if ($WsusServer) {
     $WsusCleanupManager = $WsusServer.GetCleanupManager()
-    if($WsusCleanupManager)
-    {
+    if ($WsusCleanupManager) {
         $WsusCleanupScope = New-Object Microsoft.UpdateServices.Administration.CleanupScope($DeclineSupersededUpdates,$DeclineExpiredUpdates,$CleanupObsoleteUpdates,$CompressUpdates,$CleanupObsoleteComputers,$CleanupUnneededContentFiles,$CleanupLocalPublishedContentFiles)
         $WsusCleanupResults = $WsusCleanupManager.PerformCleanup($WsusCleanupScope)
-        if($WsusCleanupResults)
-        {
-        $WsusCleanupResults | Out-File {{ log_folder }}\WsusCleanup.log -Force
+        if($WsusCleanupResults) {
+            $WsusCleanupResults | Out-File "{{ wsus_log_folder }}\WsusCleanup.log" -Force
         }
     }
+}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,6 @@
 ---
 
-use_proxy: false
 wsus_facts: true
-install_management_tools: true
-content_folder: "C:\\WSUS"
-script_folder: "{{content_folder}}\\Scripts"
-log_folder: "{{content_folder}}\\Logs"
+wsus_script_folder: "{{ wsus_content_folder }}\\Scripts"
+wsus_log_folder: "{{ wsus_content_folder }}\\Logs"
 


### PR DESCRIPTION
This is a collection of small changes.

- all remaining variables prefixed with `wsus_`
- wsus_content_folder, wsus_use_proxy and wsus_install_management_tools moved into defaults/ so the user can override them easier
- added leading underscore to variables that are only used internally (to help differentiate them)
- added a missing closing bracket in `templates/wsuscleanup.j2`
- added `changed_when: false` to tasks that don't change anything
- added quotes around paths in a few places so that paths with spaces don't break the commands